### PR TITLE
Further fix for seed crypto things

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -302,13 +302,14 @@ fn parse_ncsd(cia: &mut CiaReader) {
     cia.seek(0);
     let mut tmp: [u8; 512] = [0u8; 512];
     cia.read(&mut tmp);
-    let mut header: NcsdHdr = unsafe { std::mem::transmute(tmp) };
+    let header: NcsdHdr = unsafe { std::mem::transmute(tmp) };
     for idx in 0..header.offset_sizetable.len() {
         if header.offset_sizetable[idx].offset != 0 {
             cia.cidx = idx as u16;
             cia.content_id = idx as u32;
-            header.titleid.reverse();
-            parse_ncch(cia, (header.offset_sizetable[idx].offset * MEDIA_UNIT_SIZE).clone().into(), header.titleid);
+            let mut tid: [u8; 8] = header.titleid;
+            tid.reverse();
+            parse_ncch(cia, (header.offset_sizetable[idx].offset * MEDIA_UNIT_SIZE).clone().into(), tid);
         }
     }
 }
@@ -325,7 +326,7 @@ fn parse_ncch(cia: &mut CiaReader, offs: u64, mut titleid: [u8; 8]) {
     cia.seek(offs);
     let mut tmp = [0u8; 512];
     cia.read(&mut tmp);
-    let mut header: NcchHdr = unsafe { std::mem::transmute(tmp) };
+    let header: NcchHdr = unsafe { std::mem::transmute(tmp) };
     if titleid.iter().all(|&x| x == 0) {
         titleid = header.programid;
         titleid.reverse();
@@ -335,9 +336,7 @@ fn parse_ncch(cia: &mut CiaReader, offs: u64, mut titleid: [u8; 8]) {
 
     debug!("  Product code: {}", std::str::from_utf8(&header.productcode).unwrap());
     debug!("  KeyY: {:032X}", ncch_key_y);
-    header.titleid.reverse();
-    debug!("  Title ID: {}", hex::encode(header.titleid).to_uppercase());
-    header.titleid.reverse();
+    debug!("  Title ID: {}", hex::encode(titleid).to_uppercase());
     debug!("  Content ID: {:08X}\n", cia.content_id);
     debug!("  Format version: {}\n", header.formatversion);
 
@@ -351,7 +350,7 @@ fn parse_ncch(cia: &mut CiaReader, offs: u64, mut titleid: [u8; 8]) {
     let mut encrypted: bool = true;
 
     if flag_to_bool(header.flags[7] & 1) {
-        if flag_to_bool(header.titleid[3] & 16) { fixed_crypto = 2 } else { fixed_crypto = 1 }
+        if flag_to_bool(titleid[3] & 16) { fixed_crypto = 2 } else { fixed_crypto = 1 }
         debug!("  Uses fixed-key crypto")
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,10 +333,12 @@ fn parse_ncch(cia: &mut CiaReader, offs: u64, mut titleid: [u8; 8]) {
     }
 
     let ncch_key_y = BigEndian::read_u128(header.signature[0..16].try_into().unwrap());
+    let mut tid: [u8; 8] = header.titleid;
+    tid.reverse();
 
     debug!("  Product code: {}", std::str::from_utf8(&header.productcode).unwrap());
     debug!("  KeyY: {:032X}", ncch_key_y);
-    debug!("  Title ID: {}", hex::encode(titleid).to_uppercase());
+    debug!("  Title ID: {}", hex::encode(tid).to_uppercase());
     debug!("  Content ID: {:08X}\n", cia.content_id);
     debug!("  Format version: {}\n", header.formatversion);
 
@@ -350,7 +352,7 @@ fn parse_ncch(cia: &mut CiaReader, offs: u64, mut titleid: [u8; 8]) {
     let mut encrypted: bool = true;
 
     if flag_to_bool(header.flags[7] & 1) {
-        if flag_to_bool(titleid[3] & 16) { fixed_crypto = 2 } else { fixed_crypto = 1 }
+        if flag_to_bool(tid[3] & 16) { fixed_crypto = 2 } else { fixed_crypto = 1 }
         debug!("  Uses fixed-key crypto")
     }
 


### PR DESCRIPTION
This PR is a further work of the previous PR. It creates a reversed copy of `header.titleid` and passes it to the `parse_ncch` function, preventing `header.titleid` from being reversed multiple times. This avoids incorrect data when `parse_ncch` internally reads `header.titleid`, ensuring the correct retrieval of the `Seed Crypto KeyY` when processing multiple NCCH contents.
Additionally, this PR fixes a potential issue with incorrect parsing of `titleid[3]`, preventing possible decryption errors for system applications (`0004001x`).

Edit: The PR which do similar fix for old python3 version will be opened later on. :p
Edit x2: This PR will fix issue #7.